### PR TITLE
Change the default IP address in the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SBCL := sbcl
 # This must be the IP address of the file-server.
 # Note! Addresses on 10/8 networks are not supported, as this conflicts
 # with the network provided by qemu and VirtualBox.
-FILE_SERVER_IP := 192.168.0.123
+FILE_SERVER_IP := 127.0.0.1
 
 all:
 	@echo "Quick start:"


### PR DESCRIPTION
The default example IP address in the Makefile is probably not as good as using 127.0.0.1, which is what most people will be using.
