### PR TITLE
build-cold-image: Permit ppc64 SBCL

### DIFF
--- a/build-cold-image.lisp
+++ b/build-cold-image.lisp
@@ -8,7 +8,7 @@
 (error "Unicode support is required.")
 
 ;; The cold-generator requires a distinct (vector (unsigned-byte 64)) type.
-#-x86-64
+#-(or x86-64 ppc64)
 (error "A 64-bit SBCL is required.")
 
 (setf sb-impl::*default-external-format* :utf-8)


### PR DESCRIPTION
This patch is all that is needed to support cross-compiling Mezzano from a ppc64 host.