### PR TITLE
added a simple sandbox utility for running untrusted code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -135,3 +135,6 @@
 [submodule "home/cl-ppcre"]
 	path = home/cl-ppcre
 	url = https://github.com/edicl/cl-ppcre.git
+[submodule "home/cl-isolated"]
+	path = home/cl-isolated
+	url = https://github.com/kanru/cl-isolated

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SBCL := sbcl
 # file-server, not the public IP.
 # Note! Addresses on 10.0.2/24 networks are not supported, as this conflicts
 # with the network provided by qemu and VirtualBox.
-FILE_SERVER_IP := 192.168.1.24
+FILE_SERVER_IP := 192.168.1.555
 
 # Report an error if this hasn't been configured.
 ifeq ($(FILE_SERVER_IP),192.168.0.555)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SBCL := sbcl
 # file-server, not the public IP.
 # Note! Addresses on 10.0.2/24 networks are not supported, as this conflicts
 # with the network provided by qemu and VirtualBox.
-FILE_SERVER_IP := 192.168.1.555
+FILE_SERVER_IP := 192.168.0.555
 
 # Report an error if this hasn't been configured.
 ifeq ($(FILE_SERVER_IP),192.168.0.555)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SBCL := sbcl
 # file-server, not the public IP.
 # Note! Addresses on 10.0.2/24 networks are not supported, as this conflicts
 # with the network provided by qemu and VirtualBox.
-FILE_SERVER_IP := 192.168.0.555
+FILE_SERVER_IP := 192.168.1.24
 
 # Report an error if this hasn't been configured.
 ifeq ($(FILE_SERVER_IP),192.168.0.555)


### PR DESCRIPTION
This adds the tool cl-isolated https://github.com/kanru/cl-isolated to the home dir packages. This makes running untrusted code in a lisp operating system a little safer.